### PR TITLE
Refactor move method

### DIFF
--- a/lib/active_record_florder/base.rb
+++ b/lib/active_record_florder/base.rb
@@ -44,11 +44,15 @@ module ActiveRecordFlorder
     # @returns self {ModelInstance}
     # @api public
     def move(position)
-      position = position.to_f
+      begin
+        position = Float(position)
+      rescue ArgumentError, TypeError
+        raise ActiveRecordFlorder::Error, 'The position param requires only numbers'
+      end
 
-      fail ActiveRecordFlorder::Error, 'Position param is required' unless position
-      fail ActiveRecordFlorder::Error, 'Position should be > 0' unless (normalized_position = normalize_position(position)) > 0
       normalized_position = normalize_position(position)
+
+      raise ActiveRecordFlorder::Error, 'The position should be > 0' if normalize_position <= 0
 
       affected = ensure_position_solving(position, normalized_position)
 

--- a/lib/active_record_florder/base.rb
+++ b/lib/active_record_florder/base.rb
@@ -52,7 +52,7 @@ module ActiveRecordFlorder
 
       normalized_position = normalize_position(position)
 
-      raise ActiveRecordFlorder::Error, 'The position should be > 0' if normalize_position <= 0
+      raise ActiveRecordFlorder::Error, 'The position should be > 0' if normalized_position <= 0
 
       affected = ensure_position_solving(position, normalized_position)
 


### PR DESCRIPTION
@turboMaCk Paying the old debt

It's better to use `Float()` instead of `#to_f` which is more stricter. Doesn't accept an empty string which `#to_f` typecasts to `0.0`

I reworded a bit the exception messages as well.

I also prefer positive conditions (`if` instead `unless`).